### PR TITLE
INTRELENG-43 - Simplify logic for setting up common functionality

### DIFF
--- a/src/com/synopsys/integration/pipeline/SimplePipeline.groovy
+++ b/src/com/synopsys/integration/pipeline/SimplePipeline.groovy
@@ -48,15 +48,19 @@ class SimplePipeline extends Pipeline {
     SimplePipeline(CpsScript script, String commonRunDirectory) {
         super(script)
         this.commonRunDirectory = commonRunDirectory
-
-        addSetJdkStage()
     }
 
-    private void danaTest() {
-        ApiTokenStage apiTokenStage = new ApiTokenStage(getPipelineConfiguration(), "Black Duck Api Token")
-        addCommonStage(apiTokenStage)
-    }
+    static SimplePipeline commonPipeline(CpsScript script, String branch, String relativeDirectory, String url) {
+        SimplePipeline pipeline = new SimplePipeline(script)
+        pipeline.setDirectoryFromBranch(branch)
+        def cleanup = pipeline.addCleanupStep()
+        cleanup.setRelativeDirectory(relativeDirectory)
+        pipeline.addSetJdkStage()
+        pipeline.addGitStage(url, branch)
+        pipeline.addApiTokenStage()
 
+        return pipeline
+    }
 
     ArchiveStage addArchiveStage(String archiveFilePattern) {
         ArchiveStage archiveStage = new ArchiveStage(getPipelineConfiguration(), 'Archive')

--- a/src/com/synopsys/integration/pipeline/SimplePipeline.groovy
+++ b/src/com/synopsys/integration/pipeline/SimplePipeline.groovy
@@ -39,6 +39,16 @@ class SimplePipeline extends Pipeline {
     public static final String BUILD_URL = 'BUILD_URL'
     public static final String HUB_DETECT_URL = 'HUB_DETECT_URL'
 
+    public static SimplePipeline COMMON_PIPELINE(CpsScript script, String branch, String relativeDirectory, String url) {
+        SimplePipeline pipeline = new SimplePipeline(script)
+        pipeline.setDirectoryFromBranch(branch)
+        pipeline.addCleanupStep(relativeDirectory)
+        pipeline.addSetJdkStage()
+        pipeline.addGitStage(url, branch)
+        pipeline.addApiTokenStage()
+        return pipeline
+    }
+
     public String commonRunDirectory
 
     SimplePipeline(CpsScript script) {
@@ -48,18 +58,6 @@ class SimplePipeline extends Pipeline {
     SimplePipeline(CpsScript script, String commonRunDirectory) {
         super(script)
         this.commonRunDirectory = commonRunDirectory
-    }
-
-    static SimplePipeline commonPipeline(CpsScript script, String branch, String relativeDirectory, String url) {
-        SimplePipeline pipeline = new SimplePipeline(script)
-        pipeline.setDirectoryFromBranch(branch)
-        def cleanup = pipeline.addCleanupStep()
-        cleanup.setRelativeDirectory(relativeDirectory)
-        pipeline.addSetJdkStage()
-        pipeline.addGitStage(url, branch)
-        pipeline.addApiTokenStage()
-
-        return pipeline
     }
 
     ArchiveStage addArchiveStage(String archiveFilePattern) {
@@ -76,6 +74,12 @@ class SimplePipeline extends Pipeline {
 
     CleanupStep addCleanupStep() {
         CleanupStep cleanupStep = new CleanupStep(getPipelineConfiguration())
+        addStep(cleanupStep)
+        return cleanupStep
+    }
+
+    CleanupStep addCleanupStep(String relativeDirectory) {
+        CleanupStep cleanupStep = new CleanupStep(getPipelineConfiguration(), relativeDirectory)
         addStep(cleanupStep)
         return cleanupStep
     }

--- a/src/com/synopsys/integration/pipeline/SimplePipeline.groovy
+++ b/src/com/synopsys/integration/pipeline/SimplePipeline.groovy
@@ -48,7 +48,15 @@ class SimplePipeline extends Pipeline {
     SimplePipeline(CpsScript script, String commonRunDirectory) {
         super(script)
         this.commonRunDirectory = commonRunDirectory
+
+        addSetJdkStage()
     }
+
+    private void danaTest() {
+        ApiTokenStage apiTokenStage = new ApiTokenStage(getPipelineConfiguration(), "Black Duck Api Token")
+        addCommonStage(apiTokenStage)
+    }
+
 
     ArchiveStage addArchiveStage(String archiveFilePattern) {
         ArchiveStage archiveStage = new ArchiveStage(getPipelineConfiguration(), 'Archive')

--- a/src/com/synopsys/integration/pipeline/model/Step.groovy
+++ b/src/com/synopsys/integration/pipeline/model/Step.groovy
@@ -11,6 +11,11 @@ abstract class Step implements Serializable {
         this.pipelineConfiguration = pipelineConfiguration
     }
 
+    Step(PipelineConfiguration pipelineConfiguration, String relativeDirectory) {
+        this.pipelineConfiguration = pipelineConfiguration
+        this.relativeDirectory = relativeDirectory
+    }
+
     abstract void run() throws PipelineException, Exception
 
     public String getRelativeDirectory() {

--- a/src/com/synopsys/integration/pipeline/setup/ApiTokenStage.groovy
+++ b/src/com/synopsys/integration/pipeline/setup/ApiTokenStage.groovy
@@ -23,6 +23,8 @@ class ApiTokenStage extends Stage {
             pipelineConfiguration.scriptWrapper.setJenkinsProperty('BLACKDUCK_API_TOKEN', blackDuckApiToken)
 
             pipelineConfiguration.getLogger().info("BLACKDUCK_API_TOKEN for server ${blackDuckUrl} set as ${blackDuckApiToken}")
+        } else {
+            pipelineConfiguration.getLogger().info("BLACKDUCK_API_TOKEN not set as required BLACKDUCK_URL not set.")
         }
     }
 

--- a/src/com/synopsys/integration/pipeline/setup/ApiTokenStage.groovy
+++ b/src/com/synopsys/integration/pipeline/setup/ApiTokenStage.groovy
@@ -21,6 +21,8 @@ class ApiTokenStage extends Stage {
             String url = "${apiTokensUrl}/puretoken?vm=${blackDuckUrl}&name=${blackDuckApiTokenName}&username=${blackDuckApiTokenUsername}"
             String blackDuckApiToken = retrieveApiTokenFromServer(url)
             pipelineConfiguration.scriptWrapper.setJenkinsProperty('BLACKDUCK_API_TOKEN', blackDuckApiToken)
+
+            pipelineConfiguration.getLogger().info("BLACKDUCK_API_TOKEN for server ${blackDuckUrl} set as ${blackDuckApiToken.substring(0, 10)}")
         }
     }
 

--- a/src/com/synopsys/integration/pipeline/setup/ApiTokenStage.groovy
+++ b/src/com/synopsys/integration/pipeline/setup/ApiTokenStage.groovy
@@ -22,7 +22,7 @@ class ApiTokenStage extends Stage {
             String blackDuckApiToken = retrieveApiTokenFromServer(url)
             pipelineConfiguration.scriptWrapper.setJenkinsProperty('BLACKDUCK_API_TOKEN', blackDuckApiToken)
 
-            pipelineConfiguration.getLogger().info("BLACKDUCK_API_TOKEN for server ${blackDuckUrl} set as ${blackDuckApiToken.substring(0, 10)}")
+            pipelineConfiguration.getLogger().info("BLACKDUCK_API_TOKEN for server ${blackDuckUrl} set as ${blackDuckApiToken}")
         }
     }
 

--- a/src/com/synopsys/integration/pipeline/setup/CleanupStep.groovy
+++ b/src/com/synopsys/integration/pipeline/setup/CleanupStep.groovy
@@ -9,6 +9,10 @@ class CleanupStep extends Step {
         super(pipelineConfiguration)
     }
 
+    CleanupStep(PipelineConfiguration pipelineConfiguration, String relativeDirectory) {
+        super(pipelineConfiguration, relativeDirectory)
+    }
+
     @Override
     void run() throws PipelineException, Exception {
         getPipelineConfiguration().getScriptWrapper().deleteDir()


### PR DESCRIPTION
With the recent addition of `addApiTokenStage()`, we are now wanting to combine calls that the majority of builds use. This PR does that with the addition of `commonPipeline()`.