### PR TITLE
Add determineBranch() logic

### DIFF
--- a/src/com/synopsys/integration/pipeline/SimplePipeline.groovy
+++ b/src/com/synopsys/integration/pipeline/SimplePipeline.groovy
@@ -41,11 +41,12 @@ class SimplePipeline extends Pipeline {
 
     static SimplePipeline COMMON_PIPELINE(CpsScript script, String branch, String relativeDirectory, String url, String jdkToolName, boolean gitPolling) {
         SimplePipeline pipeline = new SimplePipeline(script)
-        pipeline.setDirectoryFromBranch(branch)
         pipeline.addCleanupStep(relativeDirectory)
         pipeline.addSetJdkStage(jdkToolName)
-        pipeline.addGitStageNoBranch(url, gitPolling)
+        def gitStage = pipeline.addGitStage(url, branch, gitPolling)
+        pipeline.setCommonRunDirectory(gitStage.getBranch())
         pipeline.addApiTokenStage()
+
         return pipeline
     }
 
@@ -140,12 +141,6 @@ class SimplePipeline extends Pipeline {
 
     GitStage addGitStage(String stageName, String url, String branch, boolean gitPolling) {
         GitStage gitStage = new GitStage(getPipelineConfiguration(), stageName, url, branch)
-        gitStage.setPoll(gitPolling)
-        return addCommonStage(gitStage)
-    }
-
-    GitStage addGitStageNoBranch(String url, boolean gitPolling) {
-        GitStage gitStage = new GitStage(getPipelineConfiguration(), 'Git', url)
         gitStage.setPoll(gitPolling)
         gitStage.determineAndSetBranch()
         return addCommonStage(gitStage)

--- a/src/com/synopsys/integration/pipeline/SimplePipeline.groovy
+++ b/src/com/synopsys/integration/pipeline/SimplePipeline.groovy
@@ -44,7 +44,7 @@ class SimplePipeline extends Pipeline {
         pipeline.setDirectoryFromBranch(branch)
         pipeline.addCleanupStep(relativeDirectory)
         pipeline.addSetJdkStage(jdkToolName)
-        pipeline.addGitStage(url, branch, gitPolling)
+        pipeline.addGitStageNoBranch(url, gitPolling)
         pipeline.addApiTokenStage()
         return pipeline
     }
@@ -141,6 +141,13 @@ class SimplePipeline extends Pipeline {
     GitStage addGitStage(String stageName, String url, String branch, boolean gitPolling) {
         GitStage gitStage = new GitStage(getPipelineConfiguration(), stageName, url, branch)
         gitStage.setPoll(gitPolling)
+        return addCommonStage(gitStage)
+    }
+
+    GitStage addGitStageNoBranch(String url, boolean gitPolling) {
+        GitStage gitStage = new GitStage(getPipelineConfiguration(), 'Git', url)
+        gitStage.setPoll(gitPolling)
+        gitStage.determineAndSetBranch()
         return addCommonStage(gitStage)
     }
 

--- a/src/com/synopsys/integration/pipeline/SimplePipeline.groovy
+++ b/src/com/synopsys/integration/pipeline/SimplePipeline.groovy
@@ -39,12 +39,12 @@ class SimplePipeline extends Pipeline {
     public static final String BUILD_URL = 'BUILD_URL'
     public static final String HUB_DETECT_URL = 'HUB_DETECT_URL'
 
-    static SimplePipeline COMMON_PIPELINE(CpsScript script, String branch, String relativeDirectory, String url) {
+    static SimplePipeline COMMON_PIPELINE(CpsScript script, String branch, String relativeDirectory, String url, String jdkToolName, boolean gitPolling) {
         SimplePipeline pipeline = new SimplePipeline(script)
         pipeline.setDirectoryFromBranch(branch)
         pipeline.addCleanupStep(relativeDirectory)
-        pipeline.addSetJdkStage()
-        pipeline.addGitStage(url, branch)
+        pipeline.addSetJdkStage(jdkToolName)
+        pipeline.addGitStage(url, branch, gitPolling)
         pipeline.addApiTokenStage()
         return pipeline
     }
@@ -61,9 +61,7 @@ class SimplePipeline extends Pipeline {
     }
 
     ArchiveStage addArchiveStage(String archiveFilePattern) {
-        ArchiveStage archiveStage = new ArchiveStage(getPipelineConfiguration(), 'Archive')
-        archiveStage.setArchiveFilePattern(archiveFilePattern)
-        return addCommonStage(archiveStage)
+        return addArchiveStage('Archive', archiveFilePattern)
     }
 
     ArchiveStage addArchiveStage(String stageName, String archiveFilePattern) {
@@ -85,10 +83,7 @@ class SimplePipeline extends Pipeline {
     }
 
     DetectStage addDetectStage(String detectCommand) {
-        detectCommand = detectCommand + ' --detect.project.codelocation.unmap=true --detect.tools.excluded=SIGNATURE_SCAN --detect.force.success=true'
-
-        DetectStage detectStage = new DetectStage(getPipelineConfiguration(), 'Detect', getJenkinsProperty(HUB_DETECT_URL), detectCommand)
-        return addCommonStage(detectStage)
+        return addDetectStage('Detect', detectCommand)
     }
 
     DetectStage addDetectStage(String stageName, String detectCommand) {
@@ -113,8 +108,7 @@ class SimplePipeline extends Pipeline {
     }
 
     GithubReleaseStage addGithubReleaseStage(String branch) {
-        GithubReleaseStage githubReleaseStage = new GithubReleaseStage(getPipelineConfiguration(), 'GitHub Release', getJenkinsBooleanProperty(RUN_RELEASE), branch)
-        return addCommonStage(githubReleaseStage)
+        return addGithubReleaseStage('GitHub Release', branch)
     }
 
     GithubReleaseStage addGithubReleaseStage(String stageName, String branch) {
@@ -123,8 +117,7 @@ class SimplePipeline extends Pipeline {
     }
 
     GithubReleaseStage addGithubReleaseStageByFile(String branch, String artifactFile) {
-        GithubReleaseStage githubReleaseStage = new GithubReleaseStage(getPipelineConfiguration(), 'GitHub Release', getJenkinsBooleanProperty(RUN_RELEASE), artifactFile, branch)
-        return addCommonStage(githubReleaseStage)
+        return addGithubReleaseStageByFile('GitHub Release', branch, artifactFile)
     }
 
     GithubReleaseStage addGithubReleaseStageByFile(String stageName, String branch, String artifactFile) {
@@ -133,8 +126,7 @@ class SimplePipeline extends Pipeline {
     }
 
     GithubReleaseStage addGithubReleaseStageByPattern(String branch, String artifactPattern, String artifactDirectory) {
-        GithubReleaseStage githubReleaseStage = new GithubReleaseStage(getPipelineConfiguration(), 'GitHub Release', getJenkinsBooleanProperty(RUN_RELEASE), artifactPattern, artifactDirectory, branch)
-        return addCommonStage(githubReleaseStage)
+        return addGithubReleaseStageByPattern('GitHub Release', branch, artifactPattern, artifactDirectory)
     }
 
     GithubReleaseStage addGithubReleaseStageByPattern(String stageName, String branch, String artifactPattern, String artifactDirectory) {
@@ -142,20 +134,18 @@ class SimplePipeline extends Pipeline {
         return addCommonStage(githubReleaseStage)
     }
 
-    GitStage addGitStage(String url, String branch) {
-        return addGitStage("Git", url, branch)
+    GitStage addGitStage(String url, String branch, boolean gitPolling) {
+        return addGitStage('Git', url, branch, gitPolling)
     }
 
-    GitStage addGitStage(String stageName, String url, String branch) {
+    GitStage addGitStage(String stageName, String url, String branch, boolean gitPolling) {
         GitStage gitStage = new GitStage(getPipelineConfiguration(), stageName, url, branch)
+        gitStage.setPoll(gitPolling)
         return addCommonStage(gitStage)
     }
 
     GradleStage addGradleStage(String gradleExe, String gradleOptions) {
-        GradleStage gradleStage = new GradleStage(getPipelineConfiguration(), "Gradle")
-        gradleStage.setGradleExe(gradleExe)
-        gradleStage.setGradleOptions(gradleOptions)
-        return addCommonStage(gradleStage)
+        return addGradleStage('Gradle', gradleExe, gradleOptions)
     }
 
     GradleStage addGradleStage(String stageName, String gradleExe, String gradleOptions) {
@@ -166,9 +156,7 @@ class SimplePipeline extends Pipeline {
     }
 
     JacocoStage addJacocoStage(LinkedHashMap jacocoOptions) {
-        JacocoStage jacocoStage = new JacocoStage(getPipelineConfiguration(), 'Jacoco')
-        jacocoStage.setJacocoOptions(jacocoOptions)
-        return addCommonStage(jacocoStage)
+        return addJacocoStage('Jacoco', jacocoOptions)
     }
 
     JacocoStage addJacocoStage(String stageName, LinkedHashMap jacocoOptions) {
@@ -178,11 +166,7 @@ class SimplePipeline extends Pipeline {
     }
 
     JunitStageWrapper addJunitStageWrapper(Stage stage, LinkedHashMap junitOptions) {
-        JunitStageWrapper junitStageWrapper = new JunitStageWrapper(getPipelineConfiguration(), 'Junit')
-        junitStageWrapper.setJunitOptions(junitOptions)
-        junitStageWrapper.setRelativeDirectory(commonRunDirectory)
-        stage.addStageWrapper(junitStageWrapper)
-        return junitStageWrapper
+        return addJunitStageWrapper(stage, 'Junit', junitOptions)
     }
 
     JunitStageWrapper addJunitStageWrapper(Stage stage, String stageName, LinkedHashMap junitOptions) {
@@ -193,12 +177,8 @@ class SimplePipeline extends Pipeline {
         return junitStageWrapper
     }
 
-
     MavenStage addMavenStage(String mavenToolName, String mavenOptions) {
-        MavenStage mavenStage = new MavenStage(getPipelineConfiguration(), "Maven")
-        mavenStage.setMavenOptions(mavenOptions)
-        mavenStage.setMavenToolName(mavenToolName)
-        return addCommonStage(mavenStage)
+        return addMavenStage('Maven', mavenToolName, mavenOptions)
     }
 
     MavenStage addMavenStage(String stageName, String mavenToolName, String mavenOptions) {
@@ -209,11 +189,7 @@ class SimplePipeline extends Pipeline {
     }
 
     NextSnapshotStage addNextSnapshotStage(String buildTool, String exe, String branch) {
-        boolean runRelease = getJenkinsBooleanProperty(RUN_RELEASE)
-        boolean runQARelease = getJenkinsBooleanProperty(RUN_QA_BUILD)
-
-        NextSnapshotStage nextSnapshotStage = new NextSnapshotStage(getPipelineConfiguration(), 'Next Snapshot', runRelease, runQARelease, buildTool, exe, branch)
-        return addCommonStage(nextSnapshotStage)
+        addNextSnapshotStage('Next Snapshot', buildTool, exe, branch)
     }
 
     NextSnapshotStage addNextSnapshotStage(String stageName, String buildTool, String exe, String branch) {
@@ -224,10 +200,7 @@ class SimplePipeline extends Pipeline {
     }
 
     RemoveSnapshotStage addRemoveSnapshotStage(String buildTool, String exe, String branch) {
-        boolean runRelease = getJenkinsBooleanProperty(RUN_RELEASE)
-        boolean runQARelease = getJenkinsBooleanProperty(RUN_QA_BUILD)
-        RemoveSnapshotStage removeSnapshotStage = new RemoveSnapshotStage(getPipelineConfiguration(), 'Remove Snapshot', runRelease, runQARelease, buildTool, exe, branch)
-        return addCommonStage(removeSnapshotStage)
+        return addRemoveSnapshotStage('Remove Snapshot', buildTool, exe, branch)
     }
 
     RemoveSnapshotStage addRemoveSnapshotStage(String stageName, String buildTool, String exe, String branch) {
@@ -238,16 +211,22 @@ class SimplePipeline extends Pipeline {
     }
 
     SetJdkStage addSetJdkStage() {
-        return addSetJdkStage("Set JDK")
+        SetJdkStage setJdkStage = new SetJdkStage(getPipelineConfiguration(), 'Set JDK')
+        return addCommonStage(setJdkStage)
     }
 
-    SetJdkStage addSetJdkStage(String stageName) {
+    SetJdkStage addSetJdkStage(String jdkToolName) {
+        return addSetJdkStage('Set JDK', jdkToolName)
+    }
+
+    SetJdkStage addSetJdkStage(String stageName, String jdkToolName) {
         SetJdkStage setJdkStage = new SetJdkStage(getPipelineConfiguration(), stageName)
+        setJdkStage.setJdkToolName(jdkToolName)
         return addCommonStage(setJdkStage)
     }
 
     ApiTokenStage addApiTokenStage() {
-        ApiTokenStage apiTokenStage = new ApiTokenStage(getPipelineConfiguration(), "Black Duck Api Token")
+        ApiTokenStage apiTokenStage = new ApiTokenStage(getPipelineConfiguration(), 'Black Duck Api Token')
         return addCommonStage(apiTokenStage)
     }
 

--- a/src/com/synopsys/integration/pipeline/jenkins/BuildWrapper.groovy
+++ b/src/com/synopsys/integration/pipeline/jenkins/BuildWrapper.groovy
@@ -1,6 +1,8 @@
 package com.synopsys.integration.pipeline.jenkins
 
 import hudson.AbortException
+import hudson.model.Cause.UpstreamCause
+import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
 
 interface BuildWrapper extends Serializable {
 
@@ -45,5 +47,9 @@ interface BuildWrapper extends Serializable {
     public List<BuildWrapper> getUpstreamBuilds() throws AbortException
 
     public String getAbsoluteUrl() throws AbortException
+
+    public RunWrapper getRunWrapper()
+
+    public UpstreamCause getUpstreamCause()
 
 }

--- a/src/com/synopsys/integration/pipeline/jenkins/BuildWrapper.groovy
+++ b/src/com/synopsys/integration/pipeline/jenkins/BuildWrapper.groovy
@@ -1,7 +1,6 @@
 package com.synopsys.integration.pipeline.jenkins
 
 import hudson.AbortException
-import hudson.model.Cause.UpstreamCause
 import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
 
 interface BuildWrapper extends Serializable {
@@ -49,7 +48,5 @@ interface BuildWrapper extends Serializable {
     public String getAbsoluteUrl() throws AbortException
 
     public RunWrapper getRunWrapper()
-
-    public UpstreamCause getUpstreamCause()
 
 }

--- a/src/com/synopsys/integration/pipeline/jenkins/BuildWrapperImpl.groovy
+++ b/src/com/synopsys/integration/pipeline/jenkins/BuildWrapperImpl.groovy
@@ -1,6 +1,7 @@
 package com.synopsys.integration.pipeline.jenkins
 
 import hudson.AbortException
+import hudson.model.Cause.UpstreamCause
 import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
 
 class BuildWrapperImpl implements BuildWrapper {
@@ -8,6 +9,8 @@ class BuildWrapperImpl implements BuildWrapper {
 
     BuildWrapperImpl(RunWrapper runWrapper) {
         this.runWrapper = runWrapper
+
+        //        runWrapper.getRawBuild().getCause(hudson.model.Cause$UpstreamCause)
     }
 
     @Override
@@ -123,7 +126,13 @@ class BuildWrapperImpl implements BuildWrapper {
         return runWrapper.getAbsoluteUrl()
     }
 
+    @Override
     RunWrapper getRunWrapper() {
         return runWrapper
+    }
+
+    @Override
+    UpstreamCause getUpstreamCause() {
+        return runWrapper.getRawBuild().getCause(Cause.UpstreamCause)
     }
 }

--- a/src/com/synopsys/integration/pipeline/jenkins/BuildWrapperImpl.groovy
+++ b/src/com/synopsys/integration/pipeline/jenkins/BuildWrapperImpl.groovy
@@ -1,7 +1,6 @@
 package com.synopsys.integration.pipeline.jenkins
 
 import hudson.AbortException
-import hudson.model.Cause.UpstreamCause
 import org.jenkinsci.plugins.workflow.support.steps.build.RunWrapper
 
 class BuildWrapperImpl implements BuildWrapper {
@@ -9,8 +8,6 @@ class BuildWrapperImpl implements BuildWrapper {
 
     BuildWrapperImpl(RunWrapper runWrapper) {
         this.runWrapper = runWrapper
-
-        //        runWrapper.getRawBuild().getCause(hudson.model.Cause$UpstreamCause)
     }
 
     @Override
@@ -131,8 +128,4 @@ class BuildWrapperImpl implements BuildWrapper {
         return runWrapper
     }
 
-    @Override
-    UpstreamCause getUpstreamCause() {
-        return runWrapper.getRawBuild().getCause(Cause.UpstreamCause)
-    }
 }

--- a/src/com/synopsys/integration/pipeline/scm/GitStage.groovy
+++ b/src/com/synopsys/integration/pipeline/scm/GitStage.groovy
@@ -1,5 +1,6 @@
 package com.synopsys.integration.pipeline.scm
 
+import com.cloudbees.groovy.cps.NonCPS
 import com.synopsys.integration.model.GithubBranchModel
 import com.synopsys.integration.pipeline.exception.PipelineException
 import com.synopsys.integration.pipeline.jenkins.PipelineConfiguration
@@ -24,7 +25,6 @@ class GitStage extends Stage {
     private String gitToolName = DEFAULT_GIT_TOOL
     private boolean changelog = DEFAULT_GIT_CHANGELOG
     private boolean poll = DEFAULT_GIT_POLL
-    private final Hudson hudson = Jenkins.get() as Hudson
 
     GitStage(PipelineConfiguration pipelineConfiguration, String stageName, String url) {
         super(pipelineConfiguration, stageName)
@@ -84,7 +84,9 @@ class GitStage extends Stage {
         return (null != nextUpstreamCause) ? nextUpstreamCause : currentUpstreamCause
     }
 
-    private WorkflowRun getBuild(Cause.UpstreamCause cause) {
+    @NonCPS
+    private static WorkflowRun getBuild(Cause.UpstreamCause cause) {
+        Hudson hudson = Jenkins.get() as Hudson
         String jobName = cause.getUpstreamProject()
         int buildNumber = cause.getUpstreamBuild()
         WorkflowJob workflowJob = hudson.getItemByFullName(jobName, WorkflowJob)

--- a/src/com/synopsys/integration/pipeline/scm/GitStage.groovy
+++ b/src/com/synopsys/integration/pipeline/scm/GitStage.groovy
@@ -49,7 +49,6 @@ class GitStage extends Stage {
     }
 
     void determineAndSetBranch() {
-        getPipelineConfiguration().getLogger().info("In determineAndSetBranch")
         WorkflowRun currentBuild = pipelineConfiguration.getScriptWrapper().currentBuild().getRunWrapper().getRawBuild() as WorkflowRun
         Cause.UpstreamCause initiatingUpstreamCause = determineUpstreamCause(currentBuild)
 

--- a/src/com/synopsys/integration/pipeline/scm/GitStage.groovy
+++ b/src/com/synopsys/integration/pipeline/scm/GitStage.groovy
@@ -5,11 +5,18 @@ import com.synopsys.integration.pipeline.exception.PipelineException
 import com.synopsys.integration.pipeline.jenkins.PipelineConfiguration
 import com.synopsys.integration.pipeline.model.Stage
 import com.synopsys.integration.utilities.GithubBranchParser
+import hudson.model.BuildListener
+import hudson.model.Cause.UpstreamCause
+import hudson.model.Hudson
+import jenkins.model.Jenkins
+import org.jenkinsci.plugins.workflow.job.WorkflowJob
+import org.jenkinsci.plugins.workflow.job.WorkflowRun
 
 class GitStage extends Stage {
     public static final String DEFAULT_GIT_TOOL = 'Default'
     public static final boolean DEFAULT_GIT_CHANGELOG = false
     public static final boolean DEFAULT_GIT_POLL = false
+    public static final String COMMIT_HASH = 'COMMIT_HASH'
 
     private final String url
     private final String branch
@@ -25,7 +32,11 @@ class GitStage extends Stage {
 
     @Override
     void stageExecution() throws PipelineException, Exception {
-        getPipelineConfiguration().getLogger().info("Pulling branch '${branch}' from repo '${url}")
+        getPipelineConfiguration().getLogger().info("DANA GET CAUSE")
+        getPipelineConfiguration().getLogger().info(getPipelineConfiguration().getScriptWrapper().currentBuild().getUpstreamCause().toString())
+        getPipelineConfiguration().getLogger().info(getPipelineConfiguration().getScriptWrapper().currentBuild().getUpstreamCause().getClass().name)
+
+        getPipelineConfiguration().getLogger().info("Pulling branch '${branch}' from repo '${url}'")
         getPipelineConfiguration().getScriptWrapper().checkout(url, branch, gitToolName, changelog, poll)
 
         String gitPath = getPipelineConfiguration().getScriptWrapper().tool(gitToolName)
@@ -40,7 +51,68 @@ class GitStage extends Stage {
 
         // Set COMMIT_HASH in environment to allow downstream jobs to use the same code
         String commitHash = getPipelineConfiguration().getScriptWrapper().executeCommand("git rev-parse HEAD", true).trim()
-        getPipelineConfiguration().getScriptWrapper().setJenkinsProperty('COMMIT_HASH', commitHash)
+        getPipelineConfiguration().getScriptWrapper().setJenkinsProperty(COMMIT_HASH, commitHash)
+        dana()
+    }
+
+    String determineBranch() {
+
+        String commitHash = ''
+        UpstreamCause upstreamCause = getPipelineConfiguration().getScriptWrapper().currentBuild().getUpstreamCause()
+
+        if (null != upstreamCause) {
+            int upstreamBuildNumber = upstreamCause.getUpstreamBuild()
+            String upstreamJobName = upstreamCause.getUpstreamProject()
+            BuildListener buildListener = Jenkins.get()
+                    .getItemByFullName(upstreamJobName, WorkflowJob)
+                    .getBuildByNumber(upstreamBuildNumber)
+                    .getListener()
+            commitHash = upstreamCause.getUpstreamRun().getEnvironment(buildListener)[COMMIT_HASH]
+        }
+
+        Jenkins.get().getItemByFullName(upstreamJobName, WorkflowJob).builds.getLastBuild().getEnvironment(buildListener)
+
+        if (commitHash?.trim()) {
+            return commitHash
+        } else {
+            GithubBranchParser githubBranchParser = new GithubBranchParser()
+            GithubBranchModel githubBranchModel = githubBranchParser.parseBranch(branch)
+            return githubBranchModel.getBranchName()
+        }
+    }
+
+    void dana() {
+        UpstreamCause upstreamCause = getPipelineConfiguration().getScriptWrapper().currentBuild().getUpstreamCause()
+
+        if (null != upstreamCause) {
+            int upstreamBuildNumber = upstreamCause.getUpstreamBuild()
+            String upstreamJobName = upstreamCause.getUpstreamProject()
+
+            Hudson hudson = Jenkins.get() as Hudson
+            WorkflowJob workflowJob = hudson.getItemByFullName(upstreamJobName, WorkflowJob)
+            WorkflowRun workflowRun = workflowJob.getBuildByNumber(upstreamBuildNumber)
+            BuildListener buildListener = workflowRun.getListener()
+
+            getPipelineConfiguration().getLogger().info("LIB:: " + hudson.getClass().name) //hudson.model.Hudson
+            getPipelineConfiguration().getLogger().info("LIB:: " + workflowJob.getClass().name) //org.jenkinsci.plugins.workflow.job.WorkflowJob
+            getPipelineConfiguration().getLogger().info("LIB:: " + workflowRun.getClass().name) //org.jenkinsci.plugins.workflow.job.WorkflowRun
+            getPipelineConfiguration().getLogger().info("LIB:: " + buildListener.getClass().name) //hudson.model.StreamBuildListener
+            getPipelineConfiguration().getLogger().info("LIB:: " + upstreamCause.getUpstreamRun().getClass().name) //org.jenkinsci.plugins.workflow.job.WorkflowRun
+            getPipelineConfiguration().getLogger().info("LIB:: " + upstreamCause.getUpstreamRun().getClass().name) //org.jenkinsci.plugins.workflow.job.WorkflowRun
+
+            getPipelineConfiguration().getLogger().info("LIB:: " + upstreamCause.getUpstreamRun().getEnvironment(buildListener)[COMMIT_HASH].getClass().name) //org.codehaus.groovy.runtime.NullObject
+
+            getPipelineConfiguration().getLogger().info("LIB:: " + workflowJob.getBuildByNumber(upstreamBuildNumber).getClass().name) //org.jenkinsci.plugins.workflow.job.WorkflowRun
+            getPipelineConfiguration().getLogger().info("LIB:: " + workflowJob.builds.getClass().name) //hudson.util.RunList
+            getPipelineConfiguration().getLogger().info("LIB:: " + workflowJob.builds.getLastBuild().getClass().name) //org.jenkinsci.plugins.workflow.job.WorkflowRun
+            getPipelineConfiguration().getLogger().info("LIB:: " + workflowJob.getBuildByNumber(upstreamBuildNumber).getEnvironment(buildListener).getClass().name) //hudson.EnvVars
+            getPipelineConfiguration().getLogger().info("LIB:: " + workflowJob.getBuildByNumber(upstreamBuildNumber).getEnvironment(buildListener)[COMMIT_HASH]) //null
+            getPipelineConfiguration().getLogger().info("LIB:: " + workflowJob.getBuildByNumber(upstreamBuildNumber).getEnvironment(buildListener).collect().getClass().name) //java.util.ArrayList
+
+            workflowJob.getBuildByNumber(upstreamBuildNumber).getEnvironment(buildListener).collect().each { it -> getPipelineConfiguration().getLogger().info("LIB:: " + it.toString())
+            }
+
+        }
     }
 
     String getGitToolName() {

--- a/src/com/synopsys/integration/pipeline/scm/GitStage.groovy
+++ b/src/com/synopsys/integration/pipeline/scm/GitStage.groovy
@@ -37,6 +37,10 @@ class GitStage extends Stage {
         getPipelineConfiguration().getScriptWrapper().executeCommandWithException("${gitPath} checkout ${githubBranchModel.getBranchName()}")
         // Do a hard reset in order to clear out any local changes/commits
         getPipelineConfiguration().getScriptWrapper().executeCommandWithException("${gitPath} reset --hard ${githubBranchModel.getBranchName()}")
+
+        // Set COMMIT_HASH in environment to allow downstream jobs to use the same code
+        String commitHash = getPipelineConfiguration().getScriptWrapper().executeCommand("git rev-parse HEAD", true).trim()
+        getPipelineConfiguration().getScriptWrapper().setJenkinsProperty('COMMIT_HASH', commitHash)
     }
 
     String getGitToolName() {

--- a/src/com/synopsys/integration/pipeline/scm/GitStage.groovy
+++ b/src/com/synopsys/integration/pipeline/scm/GitStage.groovy
@@ -6,8 +6,6 @@ import com.synopsys.integration.pipeline.jenkins.PipelineConfiguration
 import com.synopsys.integration.pipeline.model.Stage
 import com.synopsys.integration.utilities.GithubBranchParser
 
-import java.util.function.Function
-
 class GitStage extends Stage {
     public static final String DEFAULT_GIT_TOOL = 'Default'
     public static final boolean DEFAULT_GIT_CHANGELOG = false
@@ -17,7 +15,7 @@ class GitStage extends Stage {
     private final String branch
     private String gitToolName = DEFAULT_GIT_TOOL
     private boolean changelog = DEFAULT_GIT_CHANGELOG
-    private boolean poll
+    private boolean poll = DEFAULT_GIT_POLL
 
     GitStage(PipelineConfiguration pipelineConfiguration, String stageName, String url, String branch) {
         super(pipelineConfiguration, stageName)
@@ -27,8 +25,6 @@ class GitStage extends Stage {
 
     @Override
     void stageExecution() throws PipelineException, Exception {
-        poll = retrieveFromEnv('INT_GIT_POLLING', Boolean.&valueOf as Function, DEFAULT_GIT_POLL)
-
         getPipelineConfiguration().getLogger().info("Pulling branch '${branch}' from repo '${url}")
         getPipelineConfiguration().getScriptWrapper().checkout(url, branch, gitToolName, changelog, poll)
 
@@ -63,4 +59,7 @@ class GitStage extends Stage {
         return poll
     }
 
+    void setPoll(final boolean poll) {
+        this.poll = poll
+    }
 }

--- a/src/com/synopsys/integration/pipeline/setup/SetJdkStage.groovy
+++ b/src/com/synopsys/integration/pipeline/setup/SetJdkStage.groovy
@@ -7,7 +7,7 @@ import com.synopsys.integration.pipeline.model.Stage
 class SetJdkStage extends Stage {
     public static final String DEFAULT_JDK_TOOL_NAME = 'OpenJDK 11'
 
-    private String jdkToolName
+    private String jdkToolName = DEFAULT_JDK_TOOL_NAME
 
     SetJdkStage(PipelineConfiguration pipelineConfiguration, String name) {
         super(pipelineConfiguration, name)
@@ -15,7 +15,6 @@ class SetJdkStage extends Stage {
 
     @Override
     void stageExecution() throws PipelineException, Exception {
-        jdkToolName = retrieveStringFromEnv('INT_JDK_TOOL_NAME', DEFAULT_JDK_TOOL_NAME)
         getPipelineConfiguration().getLogger().info("Setting jdk = ${jdkToolName}")
 
         String toolHome = getPipelineConfiguration().getScriptWrapper().tool(jdkToolName)
@@ -29,6 +28,10 @@ class SetJdkStage extends Stage {
 
     String getJdkToolName() {
         return jdkToolName
+    }
+
+    void setJdkToolName(final String jdkToolName) {
+        this.jdkToolName = jdkToolName
     }
 
 }

--- a/src/com/synopsys/integration/pipeline/utilities/GradleUtils.groovy
+++ b/src/com/synopsys/integration/pipeline/utilities/GradleUtils.groovy
@@ -50,7 +50,7 @@ public class GradleUtils implements com.synopsys.integration.pipeline.utilities.
     public boolean checkForSnapshotDependencies(boolean checkAllDependencies) {
         String command = "${exe} dependencies -q"
         if (!checkAllDependencies) {
-            command = "${command} --configuration compile"
+            command = "${command} --configuration compileClassPath"
         }
         String dependencyText = jenkinsScriptWrapper.executeCommand(command, true)
         logger.info("Gradle dependencies")


### PR DESCRIPTION
All builds currently have a method determineBranch(). This PR moves that logic into the libraries so it can be removed from all builds.

This PR also addresses 2 issues
* The current determineBranch() only looks at the upstream build which triggered the current build. Since the **dev** build starts the process, we need **comprehensive** (and any other builds) to look at the initial build which triggered the process.
* Update --configuration parameter for getting dependencies from **compile** to **compileClassPath** to reflect recent gradle changes