### PR TITLE
IALERT-3389 - Add logic to gather information needed to trigger pushing to GCR

### DIFF
--- a/src/com/synopsys/integration/pipeline/SimplePipeline.groovy
+++ b/src/com/synopsys/integration/pipeline/SimplePipeline.groovy
@@ -17,6 +17,7 @@ import com.synopsys.integration.pipeline.setup.CleanupStep
 import com.synopsys.integration.pipeline.setup.SetJdkStage
 import com.synopsys.integration.pipeline.tools.DetectStage
 import com.synopsys.integration.pipeline.tools.DockerImage
+import com.synopsys.integration.pipeline.tools.PublishToGCR
 import com.synopsys.integration.pipeline.utilities.GradleUtils
 import com.synopsys.integration.pipeline.versioning.*
 import org.apache.commons.lang3.BooleanUtils
@@ -357,6 +358,11 @@ class SimplePipeline extends Pipeline {
     ApiTokenStage addApiTokenStage() {
         ApiTokenStage apiTokenStage = new ApiTokenStage(getPipelineConfiguration(), 'Black Duck Api Token')
         return addCommonStage(apiTokenStage)
+    }
+
+    PublishToGCR addPublishToGCR(String gcrRepo) {
+        PublishToGCR publishToGCR = new PublishToGCR(getPipelineConfiguration(), 'Publish Images to GCR', gcrRepo)
+        return addCommonStage(publishToGCR)
     }
 
     ClosureStage addStage(String stageName, Closure closure) {

--- a/src/com/synopsys/integration/pipeline/exception/PipelineException.groovy
+++ b/src/com/synopsys/integration/pipeline/exception/PipelineException.groovy
@@ -16,5 +16,5 @@ class PipelineException extends Exception {
     PipelineException(final Throwable cause) {
         super(cause)
     }
-    
+
 }

--- a/src/com/synopsys/integration/pipeline/jenkins/JenkinsScriptWrapper.groovy
+++ b/src/com/synopsys/integration/pipeline/jenkins/JenkinsScriptWrapper.groovy
@@ -71,6 +71,9 @@ interface JenkinsScriptWrapper extends Serializable {
 
     JSONObject readJsonFile(String fileName)
 
+    Map<?, ?> readYamlFile(String fileName)
+
     File[] findFileGlob(String glob)
 
+    void triggerPushToGCR(String imageList, String gcrRepo)
 }

--- a/src/com/synopsys/integration/pipeline/jenkins/JenkinsScriptWrapperDryRun.groovy
+++ b/src/com/synopsys/integration/pipeline/jenkins/JenkinsScriptWrapperDryRun.groovy
@@ -154,4 +154,10 @@ class JenkinsScriptWrapperDryRun extends JenkinsScriptWrapperImpl {
         getDryRunPipelineBuilder().addPipelineLine("readJsonFile file: ${fileName}")
         return new JSONObject()
     }
+
+    @Override
+    Map<?, ?> readYamlFile(String fileName) {
+        getDryRunPipelineBuilder().addPipelineLine("readYamlFile file: ${fileName}")
+        return new HashMap<>()
+    }
 }

--- a/src/com/synopsys/integration/pipeline/jenkins/JenkinsScriptWrapperImpl.groovy
+++ b/src/com/synopsys/integration/pipeline/jenkins/JenkinsScriptWrapperImpl.groovy
@@ -91,7 +91,7 @@ class JenkinsScriptWrapperImpl implements JenkinsScriptWrapper {
         // adding the http code checker command and sending output into jsonResponseFileName file
         String newCommand = command + " -H \"Authorization: token ${PASSWORD_SEARCH_TOKEN}\" -o ${jsonResponseFileName} -w %{http_code}"
         int receivedHttpStatusCode = Integer.parseInt(executeWithCredentials(pipelineConfiguration, newCommand, githubCredentialsId))
-        assert receivedHttpStatusCode == expectedHttpStatusCode : "Did not return ${expectedHttpStatusCode} HTTP code, not successful. Instead returned ${receivedHttpStatusCode}"
+        assert receivedHttpStatusCode == expectedHttpStatusCode: "Did not return ${expectedHttpStatusCode} HTTP code, not successful. Instead returned ${receivedHttpStatusCode}"
 
         //ensuring the output json file is in pretty formatting
         writeJsonFile(jsonResponseFileName, readJsonFile(jsonResponseFileName))
@@ -244,9 +244,10 @@ class JenkinsScriptWrapperImpl implements JenkinsScriptWrapper {
     }
 
     @Override
-    File[] findFileGlob(String glob){
-        if (glob.trim().length() == 0)
+    File[] findFileGlob(String glob) {
+        if (glob.trim().length() == 0) {
             throw new Exception("glob must contain characters")
+        }
         return script.findFiles(glob: glob)
     }
 

--- a/src/com/synopsys/integration/pipeline/jenkins/JenkinsScriptWrapperImpl.groovy
+++ b/src/com/synopsys/integration/pipeline/jenkins/JenkinsScriptWrapperImpl.groovy
@@ -3,7 +3,6 @@ package com.synopsys.integration.pipeline.jenkins
 import com.synopsys.integration.pipeline.exception.CommandExecutionException
 import com.synopsys.integration.pipeline.scm.GitStage
 import net.sf.json.JSONObject
-import org.apache.commons.lang3.StringUtils
 import org.jenkinsci.plugins.workflow.cps.CpsScript
 
 class JenkinsScriptWrapperImpl implements JenkinsScriptWrapper {
@@ -240,9 +239,19 @@ class JenkinsScriptWrapperImpl implements JenkinsScriptWrapper {
     }
 
     @Override
-    File[] findFileGlob (String glob){
+    Map<?, ?> readYamlFile(final String fileName) {
+        return script.readYaml(file: fileName)
+    }
+
+    @Override
+    File[] findFileGlob(String glob){
         if (glob.trim().length() == 0)
             throw new Exception("glob must contain characters")
         return script.findFiles(glob: glob)
+    }
+
+    @Override
+    void triggerPushToGCR(String imageData, String gcrRepo) {
+        script.build(job: 'Push_to_GCR', parameters: [script.string(name: 'IMAGE_LIST', value: imageData), script.string(name: 'GCR_REPO', value: gcrRepo)])
     }
 }

--- a/src/com/synopsys/integration/pipeline/tools/PublishToGCR.groovy
+++ b/src/com/synopsys/integration/pipeline/tools/PublishToGCR.groovy
@@ -1,0 +1,86 @@
+package com.synopsys.integration.pipeline.tools
+
+import com.synopsys.integration.pipeline.exception.PipelineException
+import com.synopsys.integration.pipeline.jenkins.JenkinsScriptWrapper
+import com.synopsys.integration.pipeline.jenkins.PipelineConfiguration
+import com.synopsys.integration.pipeline.logging.PipelineLogger
+import com.synopsys.integration.pipeline.model.Stage
+
+class PublishToGCR extends Stage {
+    private String fileGlob = 'build/**/docker-compose.yml'
+    private String imageFilter = 'alert'
+    private String delimiter = ':::'
+    private String gcrRepo
+
+    PublishToGCR(PipelineConfiguration pipelineConfiguration, String stageName, String gcrRepo) {
+        super(pipelineConfiguration, stageName)
+        this.gcrRepo = gcrRepo
+    }
+
+    @Override
+    void stageExecution() throws PipelineException, Exception {
+        String imageAndShaForBuildTrigger = ''
+        Set<String> dockerImageNames = []
+        JenkinsScriptWrapper jenkinsScriptWrapper = getPipelineConfiguration().getScriptWrapper()
+        PipelineLogger logger = getPipelineConfiguration().getLogger()
+
+        // Identify all the orchestration files
+        def files = jenkinsScriptWrapper.findFileGlob(fileGlob)
+        if (files.length == 0) {
+            throw new Exception("No files found matching input " + fileGlob)
+        }
+        logger.info("Found ${files.length} orchestration files matching ${fileGlob}")
+
+        // Parse orchestration files to get the image name
+        for (File composeFile : files) {
+            def fileAsYaml = jenkinsScriptWrapper.readYamlFile(composeFile.path)
+            for (def service : fileAsYaml.services) {
+                dockerImageNames << service.getValue().get('image')
+            }
+        }
+        logger.info("Found ${dockerImageNames.size()} unique docker image names within orchestration")
+
+        // Loop all image names to get the sha
+        for (imageName in dockerImageNames) {
+            // Once the Alert images are in Artifactory, we can remove this
+            if (!imageName.contains(imageFilter)) {
+                jenkinsScriptWrapper.executeCommandWithException("docker logout && docker rmi ${imageName} && docker pull ${imageName}")
+            }
+
+            // Get and check the sha
+            String shaFromImage = jenkinsScriptWrapper.executeCommand("docker inspect --format='{{index .RepoDigests 0}}' ${imageName}", true).trim()
+            if (!shaFromImage?.trim()) {
+                throw new Exception("Could not get sha for image " + imageName)
+            }
+
+            // Put together the string used to trigger the downstream job
+            if (imageAndShaForBuildTrigger?.trim()) {
+                imageAndShaForBuildTrigger += ','
+            }
+            imageAndShaForBuildTrigger += imageName
+            imageAndShaForBuildTrigger += delimiter
+            imageAndShaForBuildTrigger += shaFromImage
+        }
+
+        // Trigger build
+        logger.alwaysLog("Pushing to repo ${gcrRepo}")
+        logger.info("Pushing data: ${imageAndShaForBuildTrigger}")
+        jenkinsScriptWrapper.triggerPushToGCR(imageAndShaForBuildTrigger, gcrRepo)
+    }
+
+    void setFileGlob(String fileGlob) {
+        this.fileGlob = fileGlob
+    }
+
+    void setImageFilter(String imageFilter) {
+        this.imageFilter = imageFilter
+    }
+
+    void setDelimiter(String delimiter) {
+        this.delimiter = delimiter
+    }
+
+    void setGcrRepo(String gcrRepo) {
+        this.gcrRepo = gcrRepo
+    }
+}

--- a/src/com/synopsys/integration/pipeline/versioning/GithubAssetStage.groovy
+++ b/src/com/synopsys/integration/pipeline/versioning/GithubAssetStage.groovy
@@ -7,7 +7,7 @@ import com.synopsys.integration.pipeline.jenkins.PipelineConfiguration
 import com.synopsys.integration.pipeline.model.Stage
 import org.apache.commons.lang3.StringUtils
 
-class GithubAssetStage extends Stage{
+class GithubAssetStage extends Stage {
     private String githubCredentialsId
     private String glob
 
@@ -26,10 +26,11 @@ class GithubAssetStage extends Stage{
 
             def files = getPipelineConfiguration().getScriptWrapper().findFileGlob(glob)
             //throwing if no files matching glob pattern are found
-            if (files.length == 0)
+            if (files.length == 0) {
                 throw new Exception("no files found matching input " + glob)
+            }
             //taking the path of each file and uploading to the release
-            for (File file : files){
+            for (File file : files) {
                 String assetName = file.path
                 //TODO phase out curl command for direct Github API calls
                 String assetCommandLines = "curl -s -X POST -H \"Accept: application/vnd.github.v3+json\" -H \"Content-Type: \$(file -b --mime-type \"${assetName}\")\" -H \"Content-Length: \$(wc -c <\"${assetName}\" | xargs)\" -T \"${assetName}\" \"${uploadUrl}?name=\$(basename ${assetName})\""

--- a/src/com/synopsys/integration/pipeline/versioning/GithubReleaseStage.groovy
+++ b/src/com/synopsys/integration/pipeline/versioning/GithubReleaseStage.groovy
@@ -8,7 +8,7 @@ import com.synopsys.integration.pipeline.model.Stage
 
 import java.text.SimpleDateFormat
 
-class GithubReleaseStage extends Stage{
+class GithubReleaseStage extends Stage {
     public static String RELEASE_FILE = 'release.json'
     private String releaseOwner
     private String releaseRepo


### PR DESCRIPTION
We encountered a problem when pushing to the GCR repository. The issue was that a newly pushed image to hub.docker is NOT immediately available for pull. Because of this, the downstream "Push_to_GCR" job was performing a "docker pull" of the image, and getting the prior sha. To correct this, the "Push_to_GCR" was updated to perform a check of the sha, and if the received sha does not match the expected sha, it will sleep and try again.
This means we have to get the sha for all of the images we want to push to GCR. This PR adds logic to add a new stage to do this. In order to call this new stage, any build which wishes to do this will need to add:
```
pipeline.addPublishToGCR('<gcr repo>')
```

* Add new stage 'Publish Images to GCR'
* Add logic to identify images from orchestration files, get sha of unique image, create string to use to trigger other Jenkins job
* Other minor cleanup, mostly spacing related