### PR TITLE
Fix logic for setting Docker image version

### DIFF
--- a/src/com/synopsys/integration/pipeline/tools/DetectStage.groovy
+++ b/src/com/synopsys/integration/pipeline/tools/DetectStage.groovy
@@ -33,7 +33,12 @@ class DetectStage extends Stage {
             updateDetectCommand(DockerImage.DEFAULT_IMAGE_VERSION, dockerImage.getDockerVersionFromEnvironment())
 
             getPipelineConfiguration().getScriptWrapper().executeCommandWithException("docker logout")
+
             String fullImageName = dockerImage.setFullDockerImageName()
+            if (dockerImage.getDockerImageVersion().contains(DockerImage.DEFAULT_IMAGE_VERSION)) {
+                throw new RuntimeException('Must either provide a version for the image, or include a stage which calls SimplePipeline.addSetGradleVersionStage')
+            }
+
             getPipelineConfiguration().getScriptWrapper().executeCommandWithException("docker pull ${fullImageName}")
         }
 

--- a/src/com/synopsys/integration/pipeline/tools/DockerImage.groovy
+++ b/src/com/synopsys/integration/pipeline/tools/DockerImage.groovy
@@ -64,7 +64,8 @@ class DockerImage {
     }
 
     String setFullDockerImageName() {
-        setFullDockerImageName(dockerImageOrg + '/' + dockerImageName + ':' + getDockerVersionFromEnvironment())
+        setDockerImageVersion(getDockerVersionFromEnvironment())
+        setFullDockerImageName(dockerImageOrg + '/' + dockerImageName + ':' + dockerImageVersion)
         return getFullDockerImageName()
     }
 
@@ -77,11 +78,16 @@ class DockerImage {
     }
 
     String getDockerVersionFromEnvironment() {
-        String dockerVersion = pipelineConfiguration.getScriptWrapper().getJenkinsProperty(SimplePipeline.PROJECT_VERSION)
-        if (!dockerVersion?.trim()) {
-            dockerVersion = DEFAULT_IMAGE_VERSION
+        String dockerImageVersion = getDockerImageVersion()?.trim()
+        String projectVersion = pipelineConfiguration.getScriptWrapper().getJenkinsProperty(SimplePipeline.PROJECT_VERSION)?.trim()
+
+        if (dockerImageVersion && !dockerImageVersion.equals(DEFAULT_IMAGE_VERSION)) {
+            return dockerImageVersion
+        } else if (projectVersion) {
+            return projectVersion
+        } else {
+            return DEFAULT_IMAGE_VERSION
         }
-        return dockerVersion
     }
 
     String getDockerDetectParams() {


### PR DESCRIPTION
Setting the Docker image is slightly tricky due to the fact that the image version CAN be set during run time. Because of this, the DEFAULT_IMAGE_VERSION is used as a search&replace token at runtime. However, recent changes to allow performing a Docker pull broke the logic in place.
This PR addresses this recent break. The priority for the version is:
1. Version supplied with the Docker image when the stage is added
2. Getting the version at runtime with the PROJECT_VERSION variable
3. Without supplying a version or running addSetCleanedGradleVersionStage, DEFAULT_IMAGE_VERSION will be used, which will throw a stack at run time

Testing performed and expected results are as follows
**addSetCleanedGradleVersionStage** - This will get the project version from Gradle, strip any `-SIGQA` or `-SNAPSHOT`, and set an environment variable named `DETECT_PROJECT_VERSION_NAME_OVERRIDE` which will override the Detect property `--detect.project.version.name`
**addSetGradleVersionStage** - This will get the project version from Gradle and set an environment variable named `PROJECT_VERSION ` which will be used to replace DEFAULT_IMAGE_VERSION for Docker images.

| SCM Included? | Version on Image | addSetGradleVersionStage | addSetCleanedGradleVersionStage | EXP pull version | EXP scan version | EXP Proj version | Results? | Project using this combination |
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
| No | 6.12.0 | Not Called | Not Called | 6.12.0 | 6.12.0 | 6.12.0 | expected | synopsys-detect-docker |
| No | 6.12.0 | Not Called | Called | **Exception** no source |  |  | expected |
| No | 6.12.0 | Called | Not Called | **Exception** no source |  |  | expected |
| No | 6.12.0 | Called | Called | **Exception** no source |  |  | expected |
| No | None | Not Called | Not Called | **Exception** no image version |  |  | expected |
| No | None | Not Called | Called | **Exception** no source |  |  | expected |
| No | None | Called | Not Called | **Exception** no source |  |  | expected |
| No | None | Called | Called | **Exception** no source |  |  | expected |
| 6.12.2 | 6.12.0 | Not Called | Not Called | 6.12.0 | 6.12.0 | 6.12.0 | expected |
| 6.12.2 | 6.12.0 | Not Called | Called | 6.12.0 | 6.12.0 | 6.12.2 | expected |
| 6.12.2 | 6.12.0 | Called | Not Called | 6.12.0 | 6.12.0 | 6.12.0 | expected |
| 6.12.2 | 6.12.0 | Called | Called | 6.12.0 | 6.12.0 | 6.12.2 | expected |
| 6.12.2 | None | Not Called | Not Called | **Exception** no image version |  |  | expected |
| 6.12.2 | None | Not Called | Called | **Exception** no image version |  |  | expected |
| 6.12.2 | None | Called | Not Called | 6.12.2 | 6.12.2 | 6.12.2 | expected |
| 6.12.2 | None | Called | Called | 6.12.2 | 6.12.2 | 6.12.2 | expected | blackduck-alert, hub-imageinspector-ws |