### PR TITLE
Changes in the RemoveSnapshotStage for using the new qaJalojaDetect task

### DIFF
--- a/src/com/synopsys/integration/pipeline/SimplePipeline.groovy
+++ b/src/com/synopsys/integration/pipeline/SimplePipeline.groovy
@@ -330,13 +330,17 @@ class SimplePipeline extends Pipeline {
     }
 
     RemoveSnapshotStage addRemoveSnapshotStage(String buildTool, String exe, String branch) {
-        return addRemoveSnapshotStage('Remove Snapshot', buildTool, exe, branch)
+        return addRemoveSnapshotStage('Remove Snapshot', buildTool, exe, branch, '')
     }
 
-    RemoveSnapshotStage addRemoveSnapshotStage(String stageName, String buildTool, String exe, String branch) {
+    RemoveSnapshotStage addRemoveSnapshotStage(String buildTool, String exe, String branch, String buildCommand) {
+        addRemoveSnapshotStage('Remove Snapshot', buildTool, exe, branch, buildCommand)
+    }
+
+    RemoveSnapshotStage addRemoveSnapshotStage(String stageName, String buildTool, String exe, String branch, String buildCommand) {
         boolean runRelease = getJenkinsBooleanProperty(RUN_RELEASE)
         boolean runQARelease = getJenkinsBooleanProperty(RUN_QA_BUILD)
-        RemoveSnapshotStage removeSnapshotStage = new RemoveSnapshotStage(getPipelineConfiguration(), stageName, runRelease, runQARelease, buildTool, exe, branch, getUrl(), getGithubCredentialsId())
+        RemoveSnapshotStage removeSnapshotStage = new RemoveSnapshotStage(getPipelineConfiguration(), stageName, runRelease, runQARelease, buildTool, exe, buildCommand, branch, getUrl(), getGithubCredentialsId())
         return addCommonStage(removeSnapshotStage)
     }
 

--- a/src/com/synopsys/integration/pipeline/utilities/GradleUtils.groovy
+++ b/src/com/synopsys/integration/pipeline/utilities/GradleUtils.groovy
@@ -73,6 +73,16 @@ public class GradleUtils implements ToolUtils, Serializable {
     public String getCleanedProjectVersion() {
         String version = getProjectVersion()
 
+        int pRLocation = version.indexOf('-PR')
+        if (pRLocation != -1) {
+            version = version.substring(0, pRLocation)
+        }
+
+        int iDetectLocation = version.indexOf('-IDETECT')
+        if (iDetectLocation != -1) {
+            version = version.substring(0, iDetectLocation)
+        }
+
         int sigQaLocation = version.indexOf('-SIGQA')
         if (sigQaLocation != -1) {
             version = version.substring(0, sigQaLocation)

--- a/src/com/synopsys/integration/pipeline/utilities/GradleUtils.groovy
+++ b/src/com/synopsys/integration/pipeline/utilities/GradleUtils.groovy
@@ -73,11 +73,6 @@ public class GradleUtils implements ToolUtils, Serializable {
     public String getCleanedProjectVersion() {
         String version = getProjectVersion()
 
-        int pRLocation = version.indexOf('-PR')
-        if (pRLocation != -1) {
-            version = version.substring(0, pRLocation)
-        }
-
         int sigQaLocation = version.indexOf('-SIGQA')
         if (sigQaLocation != -1) {
             version = version.substring(0, sigQaLocation)

--- a/src/com/synopsys/integration/pipeline/utilities/GradleUtils.groovy
+++ b/src/com/synopsys/integration/pipeline/utilities/GradleUtils.groovy
@@ -47,6 +47,12 @@ public class GradleUtils implements ToolUtils, Serializable {
     }
 
     @Override
+    public String updateVersionForRelease(boolean runRelease, boolean runQARelease, String versionUpdateCommand) {
+        jenkinsScriptWrapper.executeCommandWithException("${exe} ${versionUpdateCommand} ")
+        return getProjectVersion()
+    }
+
+    @Override
     public boolean checkForSnapshotDependencies(boolean checkAllDependencies) {
         String command = "${exe} dependencies -q"
         if (!checkAllDependencies) {

--- a/src/com/synopsys/integration/pipeline/utilities/GradleUtils.groovy
+++ b/src/com/synopsys/integration/pipeline/utilities/GradleUtils.groovy
@@ -78,11 +78,6 @@ public class GradleUtils implements ToolUtils, Serializable {
             version = version.substring(0, pRLocation)
         }
 
-        int iDetectLocation = version.indexOf('-IDETECT')
-        if (iDetectLocation != -1) {
-            version = version.substring(0, iDetectLocation)
-        }
-
         int sigQaLocation = version.indexOf('-SIGQA')
         if (sigQaLocation != -1) {
             version = version.substring(0, sigQaLocation)

--- a/src/com/synopsys/integration/pipeline/utilities/MavenUtils.groovy
+++ b/src/com/synopsys/integration/pipeline/utilities/MavenUtils.groovy
@@ -60,6 +60,11 @@ public class MavenUtils implements ToolUtils, Serializable {
         return version
     }
 
+    @Override
+    public String updateVersionForRelease(boolean runRelease, boolean runQARelease, String versionUpdateCommand) {
+        return updateVersionForRelease(runRelease, runQARelease)
+    }
+
 
     @Override
     public boolean checkForSnapshotDependencies(boolean checkAllDependencies) {

--- a/src/com/synopsys/integration/pipeline/utilities/MavenUtils.groovy
+++ b/src/com/synopsys/integration/pipeline/utilities/MavenUtils.groovy
@@ -62,6 +62,8 @@ public class MavenUtils implements ToolUtils, Serializable {
 
     @Override
     public String updateVersionForRelease(boolean runRelease, boolean runQARelease, String versionUpdateCommand) {
+        // No customized command is used for the Maven projects. Built-in version:set from Maven is used.
+        // If any custom command is used in the future, this method will be the place to change.
         return updateVersionForRelease(runRelease, runQARelease)
     }
 

--- a/src/com/synopsys/integration/pipeline/utilities/ProjectUtils.groovy
+++ b/src/com/synopsys/integration/pipeline/utilities/ProjectUtils.groovy
@@ -64,6 +64,14 @@ public class ProjectUtils {
         return version
     }
 
+    public String updateVersionForRelease(boolean runRelease, boolean runQARelease, String versionUpdateCommand) {
+        String version = ""
+        if (null != toolUtils) {
+            version = toolUtils.updateVersionForRelease(runRelease, runQARelease, versionUpdateCommand)
+        }
+        return version
+    }
+
     public String increaseSemver(boolean runRelease, boolean runQARelease) {
         String version = ""
         if (null != toolUtils) {

--- a/src/com/synopsys/integration/pipeline/utilities/ToolUtils.groovy
+++ b/src/com/synopsys/integration/pipeline/utilities/ToolUtils.groovy
@@ -8,6 +8,8 @@ public interface ToolUtils {
 
     public String updateVersionForRelease(boolean runRelease, boolean runQARelease)
 
+    public String updateVersionForRelease(boolean runRelease, boolean runQARelease, String versionUpdateCommand)
+
     public boolean checkForSnapshotDependencies(boolean checkAllDependencies)
 
     public String increaseSemver(boolean runRelease, boolean runQARelease)


### PR DESCRIPTION
The synopsys-detect project is using a new task for their QA build versions. But currently, all the projects using this library have to use the qaJaloja task.

- Now, the `updateReleaseVersion()` method has an overloaded version that accepts a build command. So, if anyone wants to use other build commands than qaJaloja, they can use this new method.
- In the RemoveSnapshotStage, another method is added that will accept the build command from the Jenkins pipeline. If no build command is given, it will be empty string.
Those who wants to use the qaJaloja task, can keep on using the previous method. No changes were made for that.