### PR TITLE
RDSQDRN-61 - Get Detect download url dynamically

### DIFF
--- a/src/com/blackduck/integration/pipeline/SimplePipeline.groovy
+++ b/src/com/blackduck/integration/pipeline/SimplePipeline.groovy
@@ -41,7 +41,6 @@ class SimplePipeline extends Pipeline {
     public static final String BUILD_NUMBER = 'BUILD_NUMBER'
     public static final String JOB_NAME = 'JOB_NAME'
     public static final String BUILD_URL = 'BUILD_URL'
-    public static final String HUB_DETECT_URL = 'HUB_DETECT_URL'
 
     public static final String SIG_BD_HUB_SERVER_URL = 'SIG_BD_HUB_SERVER_URL'
     public static final String SIG_BD_HUB_API_TOKEN = 'SIG_BD_HUB_API_TOKEN'
@@ -120,7 +119,7 @@ class SimplePipeline extends Pipeline {
     DetectStage addDetectStage(String stageName, String detectCommand) {
         detectCommand = detectCommand + ' --detect.project.codelocation.unmap=true --detect.tools.excluded=SIGNATURE_SCAN --detect.force.success=true'
 
-        DetectStage detectStage = new DetectStage(getPipelineConfiguration(), stageName, getJenkinsProperty(HUB_DETECT_URL), detectCommand)
+        DetectStage detectStage = new DetectStage(getPipelineConfiguration(), stageName, detectCommand)
         return addCommonStage(detectStage)
     }
 
@@ -133,7 +132,7 @@ class SimplePipeline extends Pipeline {
     }
 
     DetectStage addDetectPopStage(String stageNameSuffix, String detectCommand) {
-        DetectStage detectStage = new DetectStage(getPipelineConfiguration(), "Detect " + stageNameSuffix, getJenkinsProperty(HUB_DETECT_URL), detectCommand)
+        DetectStage detectStage = new DetectStage(getPipelineConfiguration(), "Detect " + stageNameSuffix, detectCommand)
         detectStage.addDetectParameters(DetectStage.DEFAULT_DETECT_SETTINGS)
         detectStageSigBDHub(detectStage)
         return addCommonStage(detectStage)

--- a/src/com/blackduck/integration/pipeline/tools/DetectStage.groovy
+++ b/src/com/blackduck/integration/pipeline/tools/DetectStage.groovy
@@ -140,6 +140,16 @@ class DetectStage extends Stage {
         return newDetectCommand + " ${detectProperty}=${foundOverrideValue}"
     }
 
+    /*
+    configureDetectUrl() downloads the contents of the webpage stored in DEFAULT_DETECT_BASE_URL. The contents are then parsed line
+    by line, looking for all lines that contains '.sh'. For any found, each line is parsed to pull out the version of the Detect
+    script. The versions of the Detect script are then compared in order to find the highest versioned script. Once found, it will
+    then combine DEFAULT_DETECT_BASE_URL with the highest versioned script to use as the detectUrl.
+
+    This logic is being implemented in order to dynamically get the latest script, versus depending on an environment variable at
+    run time. It is a known and assumed risk that the webpage located at DEFAULT_DETECT_BASE_URL could change, which would cause
+    this method to fail and throw a stacktrace.
+     */
     private void configureDetectUrl() {
         String foundOverrideValue = pipelineConfiguration.scriptWrapper.getJenkinsProperty(DETECT_URL_OVERRIDE)
 


### PR DESCRIPTION
We currently have a dependency on an environment variable (HUB_DETECT_URL) which is set in Jenkins. This is not maintained, and our jobs have been running with Detect 8. The latest Detect is 10.

CHANGES
* Remove logic around HUB_DETECT_URL
* Add logic to allow an environment variable named DETECT_URL_OVERRIDE. If set, this will be used.
* If DETECT_URL_OVERRIDE is not set, parse the latest version from https://detect.blackduck.com/
  * As Jenkins master does not allow creation of files, this logic uses InputStreamReader and checks each line of data for .sh file