### PR TITLE
RDSQDRN-64 - Remove calling ApiTokenStage as part of COMMON_PIPELINE

### DIFF
--- a/src/com/blackduck/integration/pipeline/SimplePipeline.groovy
+++ b/src/com/blackduck/integration/pipeline/SimplePipeline.groovy
@@ -71,8 +71,6 @@ class SimplePipeline extends Pipeline {
         gitStage.setChangelog(true)
         pipeline.setGithubCredentialsId(gitStage.getCredentialsId())
 
-        pipeline.addApiTokenStage()
-
         return pipeline
     }
 


### PR DESCRIPTION
Remove calling ApiTokenStage as part of COMMON_PIPELINE.

This is being done to eliminate the dependence on Chitstop. Instead, a new Jenkins job was added to generate the token needed at runtime.