### PR TITLE
IALERT-3910 - Add ability to set code location name

### DIFF
--- a/src/com/blackduck/integration/pipeline/SimplePipeline.groovy
+++ b/src/com/blackduck/integration/pipeline/SimplePipeline.groovy
@@ -146,21 +146,33 @@ class SimplePipeline extends Pipeline {
     }
 
     DetectStage addDetectPopDockerStage(String imageName) {
-        return addDetectPopDockerStage(imageName, "")
+        return addDetectPopDockerStage(imageName, "", false)
+    }
+
+    DetectStage addDetectPopDockerStage(String imageName, boolean codeLocationNameAsImage) {
+        return addDetectPopDockerStage(imageName, "", codeLocationNameAsImage)
     }
 
     ArrayList<DetectStage> addDetectPopDockerStages(ArrayList<String> imageNames) {
         return addDetectPopDockerStages(imageNames, "")
     }
 
+    ArrayList<DetectStage> addDetectPopDockerStages(ArrayList<String> imageNames, boolean codeLocationNameAsImage) {
+        return addDetectPopDockerStages(imageNames, "", codeLocationNameAsImage)
+    }
+
     ArrayList<DetectStage> addDetectPopDockerStages(ArrayList<String> imageNames, String detectCommand) {
+        return addDetectPopDockerStages(imageNames, detectCommand, false)
+    }
+
+    ArrayList<DetectStage> addDetectPopDockerStages(ArrayList<String> imageNames, String detectCommand, boolean codeLocationNameAsImage) {
         ArrayList<DetectStage> detectStages = []
-        imageNames.each { imageName -> detectStages << addDetectPopDockerStage(imageName, detectCommand) }
+        imageNames.each { imageName -> detectStages << addDetectPopDockerStage(imageName, detectCommand, codeLocationNameAsImage) }
         return detectStages
     }
 
-    DetectStage addDetectPopDockerStage(String imageName, String detectCommand) {
-        DockerImage dockerImage = new DockerImage(pipelineConfiguration, imageName)
+    DetectStage addDetectPopDockerStage(String imageName, String detectCommand, boolean codeLocationNameAsImage) {
+        DockerImage dockerImage = new DockerImage(pipelineConfiguration, imageName, codeLocationNameAsImage)
         DetectStage detectDockerStage = addDetectPopStage(dockerImage.getBdProjectName(), detectCommand)
         detectDockerStage.setDockerImage(dockerImage)
         return detectDockerStage

--- a/src/com/blackduck/integration/pipeline/tools/DetectStage.groovy
+++ b/src/com/blackduck/integration/pipeline/tools/DetectStage.groovy
@@ -40,6 +40,8 @@ class DetectStage extends Stage {
             }
 
             getPipelineConfiguration().getScriptWrapper().executeCommandWithException("docker pull ${fullImageName}")
+
+            addDetectParameters(dockerImage.getCodeLocationNameAsImage(pipelineConfiguration.scriptWrapper.getJenkinsProperty(DETECT_PROJECT_VERSION_NAME_OVERRIDE)))
         }
 
         String combinedDetectParameters = "${blackduckConnection} ${getDetectCommand()} ${getDefaultExclusionParameters()}"

--- a/src/com/blackduck/integration/pipeline/tools/DockerImage.groovy
+++ b/src/com/blackduck/integration/pipeline/tools/DockerImage.groovy
@@ -9,6 +9,7 @@ class DockerImage {
 
     private PipelineConfiguration pipelineConfiguration
     private final String rawDockerImage
+    private final boolean codeLocationNameAsImage
     private final String dockerImageOrg
     private final String dockerImageName
     private final String bdProjectName
@@ -16,9 +17,10 @@ class DockerImage {
     private String fullDockerImageName
     private String dockerImageVersion
 
-    DockerImage(PipelineConfiguration pipelineConfiguration, String rawDockerImage) {
+    DockerImage(PipelineConfiguration pipelineConfiguration, String rawDockerImage, boolean codeLocationNameAsImage) {
         this.pipelineConfiguration = pipelineConfiguration
         this.rawDockerImage = rawDockerImage
+        this.codeLocationNameAsImage = codeLocationNameAsImage
 
         int slashIndex = getSlashIndex()
         this.dockerImageOrg = rawDockerImage.substring(0, slashIndex)
@@ -87,6 +89,15 @@ class DockerImage {
             return projectVersion
         } else {
             return DEFAULT_IMAGE_VERSION
+        }
+    }
+
+    String getCodeLocationNameAsImage(String version) {
+        if (codeLocationNameAsImage) {
+            pipelineConfiguration.getLogger().info("Using Detect option: detect.code.location.name")
+            return ' --detect.code.location.name=' + dockerImageOrg + "_" + dockerImageName + '_' + version
+        } else {
+            return ''
         }
     }
 


### PR DESCRIPTION
**PROBLEM:** When scanning Docker images, Detect uses the name of the version of the image as part of the scan location name. In the case of Alert, we do 'QA releases'. So, prior to release, we could have multiple versions for the images, meaning each will create a unique scan location name. This also means that if we address vulnerable dependencies in one QA version, they will still be present in the BOM because of the unique versioning we use. Detect already has the ability to address this with the option `--detect.code.location.name`. See screenshot below for the number of scan locations we have for Alert 8.0.0

**SOLUTION:** This change adds a boolean parameter to `DockerImage.groovy`. If set to true, this will append `--detect.code.location.name=` parameter, with the image org, name, and "cleaned" version. The cleaned version is the version with -SIGQA and -SNAPSHOT stripped off. So this means if the input image is `blackducksoftware/blackduck-alert:9.0.0-SNAPSHOT`, this process will append `--detect.code.location.name=blackducksoftware_blackduck-alert_9.0.0` to the process. This was tested with the Alert 9.0.0 images.

<img width="1265" height="878" alt="image" src="https://github.com/user-attachments/assets/e323a738-fbf4-4956-9cbe-15b9abf030e1" />
