### PR TITLE
IALERT-4033 - Adjust Detect params for Image scan

### DIFF
--- a/src/com/blackduck/integration/pipeline/tools/DetectStage.groovy
+++ b/src/com/blackduck/integration/pipeline/tools/DetectStage.groovy
@@ -103,7 +103,7 @@ class DetectStage extends Stage {
 
     private void addDockerImageOptions() {
         if (dockerImage) {
-            String dockerImageOptions = dockerImage.getDockerDetectParams()
+            String dockerImageOptions = dockerImage.getDockerDetectParams(detectCommand)
             addDetectParameters(dockerImageOptions)
         }
     }

--- a/src/com/blackduck/integration/pipeline/tools/DetectStage.groovy
+++ b/src/com/blackduck/integration/pipeline/tools/DetectStage.groovy
@@ -49,7 +49,7 @@ class DetectStage extends Stage {
                 String imageNameAsString = dockerImage.getImageNameAsString(projectVersionName)
 
                 String tarFileName = imageNameAsString + ".tar"
-                getPipelineConfiguration().getScriptWrapper().executeCommandWithException("docker save -o ${tarFileName}")
+                getPipelineConfiguration().getScriptWrapper().executeCommandWithException("docker save ${fullImageName} -o ${tarFileName}")
 
                 addDetectParameters(' --detect.container.scan.file.path=' + tarFileName)
             }

--- a/src/com/blackduck/integration/pipeline/tools/DetectStage.groovy
+++ b/src/com/blackduck/integration/pipeline/tools/DetectStage.groovy
@@ -41,7 +41,18 @@ class DetectStage extends Stage {
 
             getPipelineConfiguration().getScriptWrapper().executeCommandWithException("docker pull ${fullImageName}")
 
-            addDetectParameters(dockerImage.getCodeLocationNameAsImage(pipelineConfiguration.scriptWrapper.getJenkinsProperty(DETECT_PROJECT_VERSION_NAME_OVERRIDE)))
+            String projectVersionName = pipelineConfiguration.scriptWrapper.getJenkinsProperty(DETECT_PROJECT_VERSION_NAME_OVERRIDE)
+
+            addDetectParameters(dockerImage.getCodeLocationNameAsImage(projectVersionName))
+
+            if (detectCommand.contains("--detect.tools=CONTAINER_SCAN")) {
+                String imageNameAsString = dockerImage.getImageNameAsString(projectVersionName)
+
+                String tarFileName = imageNameAsString + ".tar"
+                getPipelineConfiguration().getScriptWrapper().executeCommandWithException("docker save -o ${tarFileName}")
+
+                addDetectParameters(' --detect.container.scan.file.path=' + tarFileName)
+            }
         }
 
         String combinedDetectParameters = "${blackduckConnection} ${getDetectCommand()} ${getDefaultExclusionParameters()}"

--- a/src/com/blackduck/integration/pipeline/tools/DockerImage.groovy
+++ b/src/com/blackduck/integration/pipeline/tools/DockerImage.groovy
@@ -92,10 +92,14 @@ class DockerImage {
         }
     }
 
+    String getImageNameAsString(String version) {
+        return dockerImageOrg + "_" + dockerImageName + '_' + version
+    }
+
     String getCodeLocationNameAsImage(String version) {
         if (codeLocationNameAsImage) {
             pipelineConfiguration.getLogger().info("Using Detect option: detect.code.location.name")
-            return ' --detect.code.location.name=' + dockerImageOrg + "_" + dockerImageName + '_' + version
+            return ' --detect.code.location.name=' + getImageNameAsString(version)
         } else {
             return ''
         }
@@ -112,9 +116,13 @@ class DockerImage {
         String dockerDetectParams = "--detect.docker.image=${fullDockerImageName} --detect.project.name=${bdProjectName} --detect.project.version.name=${dockerImageVersion}"
 
         if (detectCommand.contains('--detect.target.type=IMAGE') && detectCommand.contains('--detect.tools=CONTAINER_SCAN') ) {
-            throw new RuntimeException("Detect run command contains conflicting args: --detect.target.type && --detect.tools")
+            throw new RuntimeException("Detect run command contains conflicting args: '--detect.target.type' and '--detect.tools'")
         } else if (!detectCommand.contains('--detect.target.type=IMAGE') && !detectCommand.contains('--detect.tools=CONTAINER_SCAN') ) {
+            pipelineConfiguration.getLogger().info("Running image scan but type of image scan not specified.")
+            pipelineConfiguration.getLogger().info("Appending '--detect.tools=CONTAINER_SCAN' to Detect command.")
             dockerDetectParams += ' --detect.tools=CONTAINER_SCAN'
+        } else {
+            pipelineConfiguration.getLogger().info("Running image scan with included type of scan, either IMAGE or CONTAINER_SCAN.")
         }
 
         return dockerDetectParams

--- a/src/com/blackduck/integration/pipeline/tools/DockerImage.groovy
+++ b/src/com/blackduck/integration/pipeline/tools/DockerImage.groovy
@@ -101,7 +101,7 @@ class DockerImage {
         }
     }
 
-    String getDockerDetectParams() {
+    String getDockerDetectParams(String detectCommand) {
         if (!dockerImageVersion?.trim()) {
             setDockerImageVersion(getDockerVersionFromEnvironment())
             pipelineConfiguration.getLogger().info("Using environment variable '${SimplePipeline.PROJECT_VERSION}' for docker image")
@@ -109,6 +109,14 @@ class DockerImage {
 
         setFullDockerImageName(dockerImageOrg + '/' + dockerImageName + ':' + dockerImageVersion)
 
-        return "--detect.docker.image=${fullDockerImageName} --detect.target.type=IMAGE --detect.project.name=${bdProjectName} --detect.project.version.name=${dockerImageVersion}"
+        String dockerDetectParams = "--detect.docker.image=${fullDockerImageName} --detect.project.name=${bdProjectName} --detect.project.version.name=${dockerImageVersion}"
+
+        if (detectCommand.contains('--detect.target.type=IMAGE') && detectCommand.contains('--detect.tools=CONTAINER_SCAN') ) {
+            throw new RuntimeException("Detect run command contains conflicting args: --detect.target.type && --detect.tools")
+        } else if (!detectCommand.contains('--detect.target.type=IMAGE') && !detectCommand.contains('--detect.tools=CONTAINER_SCAN') ) {
+            dockerDetectParams += ' --detect.tools=CONTAINER_SCAN'
+        }
+
+        return dockerDetectParams
     }
 }

--- a/src/com/blackduck/integration/pipeline/tools/DockerImage.groovy
+++ b/src/com/blackduck/integration/pipeline/tools/DockerImage.groovy
@@ -116,7 +116,7 @@ class DockerImage {
         String dockerDetectParams = "--detect.docker.image=${fullDockerImageName} --detect.project.name=${bdProjectName} --detect.project.version.name=${dockerImageVersion}"
 
         if (detectCommand.contains('--detect.target.type=IMAGE') && detectCommand.contains('--detect.tools=CONTAINER_SCAN') ) {
-            throw new RuntimeException("Detect run command contains conflicting args: '--detect.target.type' and '--detect.tools'")
+            throw new RuntimeException("Detect run command contains conflicting args: '--detect.target.type=IMAGE' and '--detect.tools=CONTAINER_SCAN'")
         } else if (!detectCommand.contains('--detect.target.type=IMAGE') && !detectCommand.contains('--detect.tools=CONTAINER_SCAN') ) {
             pipelineConfiguration.getLogger().info("Running image scan but type of image scan not specified.")
             pipelineConfiguration.getLogger().info("Appending '--detect.tools=CONTAINER_SCAN' to Detect command.")


### PR DESCRIPTION
As `--detect.tools=CONTAINER_SCAN` is the preferred way for scanning, update the library to use it. The 4 scenarios are:
* Pass in and use `--detect.tools=CONTAINER_SCAN`
* Pass in and use `--detect.target.type=IMAGE`
* Pass in neither, and default to `--detect.tools=CONTAINER_SCAN`
* Pass in both and fail

All 4 scenarios above were tested successfully.